### PR TITLE
fix: correct license to Apache-2.0 and fix browser/CDN docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # image-exporter
 
 [![npm version](https://img.shields.io/npm/v/image-exporter.svg)](https://www.npmjs.com/package/image-exporter)
-[![license](https://img.shields.io/npm/l/image-exporter.svg)](https://github.com/briantuckerdesign/image-exporter/blob/main/LICENSE)
+[![license](https://img.shields.io/npm/l/image-exporter.svg)](https://github.com/briantuckerdesign/image-exporter/blob/main/LICENSE.md)
 
 A client-side JavaScript tool that downloads DOM elements as images. It can be imported using your favorite package manager or attached directly to the window.
 
@@ -34,7 +34,11 @@ const images = await capture(artboards, {
 ### Browser
 
 ```html
-<script src="your-path/image-exporter.umd.js" type="text/javascript"></script>
+<!-- Self-hosted -->
+<script src="your-path/index.browser.js" type="text/javascript"></script>
+
+<!-- Or via CDN -->
+<script src="https://unpkg.com/image-exporter" type="text/javascript"></script>
 
 <div class="artboard">I will be downloaded.</div>
 
@@ -186,4 +190,4 @@ Bundled with Bun and written in TypeScript.
 
 ## License
 
-ISC License - see [LICENSE](LICENSE) for details.
+Apache-2.0 License - see [LICENSE.md](LICENSE.md) for details.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "browser": "./dist/index.browser.js",
+  "unpkg": "./dist/index.browser.js",
+  "jsdelivr": "./dist/index.browser.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -39,7 +41,7 @@
     "gennyflow"
   ],
   "author": "Brian Tucker",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/briantuckerdesign/image-exporter/issues"
   },


### PR DESCRIPTION
## Phase 0 — config & docs fixes (no code changes)

First slice of the modernization plan. Metadata/docs only.

### Changes
- **License:** `package.json` `license` `ISC` → `Apache-2.0` to match the actual `LICENSE.md` (Apache 2.0). README badge + License section updated and pointed at `LICENSE.md`.
- **Browser usage:** README referenced `image-exporter.umd.js`, which the build never produces. Replaced with the real IIFE build `dist/index.browser.js` plus a CDN example.
- **CDN fields:** added `unpkg`/`jsdelivr` to `package.json` so `https://unpkg.com/image-exporter` resolves to the IIFE build.

### Why
License mismatch is an adoption/legal blocker; the broken browser path breaks copy-paste onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)