### PR TITLE
test: add bun test harness (happy-dom + no-DOM paths)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "build": "bun run scripts/build.ts",
+    "test": "bun run test:dom && bun run test:node",
+    "test:dom": "bun test --preload ./test/happydom.ts dom.test",
+    "test:node": "bun test node.test",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "prepublishOnly": "bun run build"
   },
   "repository": {
@@ -51,6 +55,8 @@
     "modern-screenshot": "^4.6.0"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.10.6",
+    "@types/bun": "^1.3.14",
     "concurrently": "^9.1.2",
     "http-server": "^14.1.1",
     "typescript": "^5.7.3"

--- a/test/happydom.ts
+++ b/test/happydom.ts
@@ -1,0 +1,13 @@
+/**
+ * happy-dom preload for browser-style tests.
+ *
+ * Registers a lightweight DOM (window, document, etc.) onto globalThis so that
+ * code depending on the browser environment can run under `bun test`.
+ *
+ * Only loaded by the `test:dom` script via `--preload`. The `test:node` script
+ * deliberately does NOT load this, giving us a true no-DOM environment for
+ * testing SSR / server-side safety.
+ */
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();

--- a/test/smoke.dom.test.ts
+++ b/test/smoke.dom.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test";
+
+/**
+ * Smoke test for the DOM test environment.
+ *
+ * Proves that the happy-dom preload is active: `document` exists and we can
+ * create and query real elements. Real unit tests for capture logic build on
+ * this same environment.
+ */
+test("happy-dom is registered: document is available", () => {
+  expect(typeof window).toBe("object");
+  expect(typeof document).toBe("object");
+
+  const el = document.createElement("div");
+  el.className = "artboard";
+  el.textContent = "hello";
+  document.body.appendChild(el);
+
+  expect(document.querySelector(".artboard")?.textContent).toBe("hello");
+
+  el.remove();
+});

--- a/test/smoke.node.test.ts
+++ b/test/smoke.node.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test";
+
+/**
+ * Smoke test for the no-DOM (Node / SSR) test environment.
+ *
+ * Proves that the `test:node` script runs WITHOUT happy-dom: there is no
+ * global `window`. This is the environment used to verify the package is safe
+ * to import in SSR / server contexts (Phase 2, bug #1).
+ */
+test("no-DOM environment: window is undefined", () => {
+  expect(typeof window).toBe("undefined");
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Phase 1 — test harness

Stacked on #3. Stands up `bun test` so the rest of the work can be done test-first.

### Key design: two environments
happy-dom injects a global `window`, which would **hide** the SSR-import crash (bug #1). So the harness has two paths:

| script | files | env |
|--------|-------|-----|
| `test:dom` | `*.dom.test.ts` | happy-dom preloaded (`window`/`document`) |
| `test:node` | `*.node.test.ts` | no DOM (`typeof window === "undefined"`) |

`bun run test` runs both. `bun run typecheck` type-checks src + test via `tsconfig.test.json`.

### Added
- dev deps: `@happy-dom/global-registrator`, `@types/bun`
- `test/happydom.ts` registrator (loaded only by `test:dom` via `--preload`)
- smoke test per environment (both green)
- `tsconfig.test.json` + `typecheck` script

### Follow-up noted for Phase 3
`bun.lock` is currently gitignored (`*.lock`) → not committed → non-reproducible CI installs. Will un-ignore + `--frozen-lockfile` in the CI phase.