### PR TITLE
fix: include webp in invalid-format error message (#9)

### DIFF
--- a/src/capture/get-image-options.dom.test.ts
+++ b/src/capture/get-image-options.dom.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, spyOn } from "bun:test";
+import { getImageOptions } from "./get-image-options";
+import { defaultConfig } from "../config";
+
+/**
+ * Bug #9: when an invalid format is provided, the error message must list ALL
+ * accepted formats. webp is supported but was missing from the message.
+ */
+test("invalid format error message lists webp as an accepted value", async () => {
+  const el = document.createElement("div");
+  el.dataset.format = "gif"; // not supported -> triggers the error path
+
+  const spy = spyOn(console, "error").mockImplementation(() => {});
+  await getImageOptions(el, defaultConfig);
+  const logged = spy.mock.calls
+    .map((args) => args.map((a) => String(a)).join(" "))
+    .join("\n");
+  spy.mockRestore();
+
+  expect(logged).toContain("webp");
+});
+
+test("invalid format falls back to the config default", async () => {
+  const el = document.createElement("div");
+  el.dataset.format = "gif";
+
+  const spy = spyOn(console, "error").mockImplementation(() => {});
+  const options = await getImageOptions(el, defaultConfig);
+  spy.mockRestore();
+
+  expect(options.format).toBe(defaultConfig.format);
+});

--- a/src/capture/get-image-options.ts
+++ b/src/capture/get-image-options.ts
@@ -94,7 +94,7 @@ export async function getImageOptions(
           `ImageExporter: provided format is not valid.
             Provided: ${format}
             Element: ${element}
-            Accepted values: jpg, png, svg, 
+            Accepted values: jpg, png, svg, webp
             Defaulting to: ${config.format}`
         );
       }


### PR DESCRIPTION
## Phase 2 · bug #9 — webp missing from error message

Stacked on #4. First red→green fix.

`parseFormat` accepts `jpg | png | svg | webp`, but its invalid-format error message listed only `jpg, png, svg,` — implying webp is invalid.

### Red → Green
- Added `get-image-options.dom.test.ts`: asserts the error message contains `webp`, plus a fallback test. Failed first (message lacked webp), passes after the one-line fix.

Tiny change, but establishes the test-first rhythm for the rest of Phase 2.