### PR TITLE
fix: count every capture in progress total (#5)

### DIFF
--- a/src/capture/determine-total-elements.dom.test.ts
+++ b/src/capture/determine-total-elements.dom.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test";
+import { determineTotalElements } from "./determine-total-elements";
+import { defaultConfig } from "../config";
+
+function div(scale?: string): HTMLElement {
+  const el = document.createElement("div");
+  if (scale !== undefined) el.dataset.scale = scale;
+  return el;
+}
+
+/**
+ * Bug #5: progress total must match the number of captures that will actually
+ * happen. Each element captures at least once; a comma-list captures once per
+ * scale. The old version skipped (counted 0 for) elements with no data-scale.
+ */
+test("element with no data-scale counts as 1", async () => {
+  expect(await determineTotalElements([div()], defaultConfig)).toBe(1);
+});
+
+test("element with a single scale counts as 1", async () => {
+  expect(await determineTotalElements([div("2")], defaultConfig)).toBe(1);
+});
+
+test("element with a multi-scale list counts once per scale", async () => {
+  expect(await determineTotalElements([div("1,2,3")], defaultConfig)).toBe(3);
+});
+
+test("invalid scale falls back to one capture", async () => {
+  expect(await determineTotalElements([div("nope")], defaultConfig)).toBe(1);
+});
+
+test("mixed elements sum correctly", async () => {
+  const els = [div(), div("1,2"), div("nope")]; // 1 + 2 + 1
+  expect(await determineTotalElements(els, defaultConfig)).toBe(4);
+});
+
+test("no data-scale uses config.scale array length", async () => {
+  const config = { ...defaultConfig, scale: [1, 2] };
+  expect(await determineTotalElements([div()], config)).toBe(2);
+});

--- a/src/capture/determine-total-elements.ts
+++ b/src/capture/determine-total-elements.ts
@@ -1,40 +1,54 @@
+import { Config } from "../types";
+
 /**
  * determineTotalElements
  *
- * Just used for progress logging to show progress of all element captures.
+ * Computes how many captures will occur across all elements, so progress
+ * logging reflects multi-scale captures (not just elements.length).
  *
- * This emcompasses multi-scale captures unlike elements.length.
+ * Each element produces at least one capture. A `data-scale` comma-list
+ * produces one capture per scale. An element with no (or an invalid)
+ * `data-scale` falls back to `config.scale`, mirroring `getImageOptions`.
  */
 export async function determineTotalElements(
-  elements: HTMLElement[] | NodeListOf<HTMLElement>
+  elements: HTMLElement[] | NodeListOf<HTMLElement>,
+  config: Config
 ): Promise<number> {
   try {
     let totalElements = 0;
-
-    for (const element of elements) {
-      const scaleAsString = element.dataset.scale;
-      if (!scaleAsString) continue;
-
-      if (scaleAsString.includes(",")) {
-        const scales = scaleAsString
-          .trim()
-          .split(",")
-          .map((scale) => parseFloat(scale));
-
-        if (scales.some((scale) => isNaN(scale))) continue;
-        totalElements += scales.length;
-      } else {
-        const scaleAsNumber = parseFloat(scaleAsString.trim());
-        if (isNaN(scaleAsNumber)) {
-          continue;
-        } else {
-          totalElements++;
-        }
-      }
+    for (const element of Array.from(elements)) {
+      totalElements += countScalesForElement(element, config);
     }
-
     return totalElements;
   } catch (error) {
     return 1;
   }
+}
+
+/** Number of captures a single element will produce. */
+function countScalesForElement(element: HTMLElement, config: Config): number {
+  const scaleAsString = element.dataset.scale;
+
+  // No override: use the configured default scale.
+  if (!scaleAsString) return countConfigScale(config);
+
+  if (scaleAsString.includes(",")) {
+    const scales = scaleAsString
+      .trim()
+      .split(",")
+      .map((scale) => parseFloat(scale));
+    // Invalid list -> getImageOptions falls back to config.scale.
+    if (scales.some((scale) => isNaN(scale))) return countConfigScale(config);
+    return scales.length;
+  }
+
+  const scaleAsNumber = parseFloat(scaleAsString.trim());
+  // Invalid single value -> getImageOptions falls back to config.scale.
+  if (isNaN(scaleAsNumber)) return countConfigScale(config);
+  return 1;
+}
+
+/** Captures implied by the config's default scale (array => one per scale). */
+function countConfigScale(config: Config): number {
+  return Array.isArray(config.scale) ? config.scale.length : 1;
 }

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -33,7 +33,7 @@ export async function capture(
     const originalLength = elements.length;
     elements = removeHiddenElements(elements);
 
-    const totalElements = await determineTotalElements(elements);
+    const totalElements = await determineTotalElements(elements, config);
 
     if (originalLength !== elements.length)
       log.verbose(


### PR DESCRIPTION
## Phase 2 · bug #5 — progress total undercounts

Stacked on #5.

`determineTotalElements` did `continue` for elements with no `data-scale`, counting them as **0**. With such elements the progress total was too low and never reached 100%.

### Fix
- Every element counts as at least 1 capture.
- Comma-list `data-scale` counts once per scale (the multi-scale case from the report).
- No-scale / invalid `data-scale` falls back to `config.scale`, mirroring `getImageOptions`. Function now takes `config` so config-level scale arrays are counted too.

### Red → Green
6 cases in `determine-total-elements.dom.test.ts` (no-scale, single, multi, invalid, mixed sum, config-array). 4 failed before, all pass now.