### PR TITLE
fix: unify filename dedup into shared makeUnique helper (#8)

### DIFF
--- a/src/capture/capture-element.ts
+++ b/src/capture/capture-element.ts
@@ -10,7 +10,7 @@ import * as modernScreenshot from "modern-screenshot";
 export async function captureElement(
   element: HTMLElement,
   imageOptions: ParsedImageOptions,
-  filenames: string[]
+  seen: Set<string>
 ): Promise<Image> {
   try {
     let dataURL = "";
@@ -61,7 +61,7 @@ export async function captureElement(
 
     return {
       dataURL,
-      fileName: handleFileNames(imageOptions, filenames),
+      fileName: handleFileNames(imageOptions, seen),
     };
   } catch (error) {
     console.error("ImageExporter: Error in captureImage", error);

--- a/src/capture/dedup-consistency.node.test.ts
+++ b/src/capture/dedup-consistency.node.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+import { handleFileNames } from "./handle-filenames";
+import { ensureUniqueFileNames } from "./download-images";
+import { ImageOptions } from "../types";
+
+/**
+ * Bug #8: capture-time naming (handleFileNames) and the public downloadImages
+ * dedup (ensureUniqueFileNames) must produce identical results for the same
+ * set of colliding names, since both now use the shared makeUnique helper.
+ */
+const opts: ImageOptions = {
+  label: "a",
+  format: "png",
+  scale: 1,
+  quality: 1,
+  includeScaleInLabel: false,
+};
+
+test("both dedup paths agree on three colliding names", () => {
+  const seen = new Set<string>();
+  const viaCapture = [
+    handleFileNames(opts, seen),
+    handleFileNames(opts, seen),
+    handleFileNames(opts, seen),
+  ];
+
+  const viaDownload = ensureUniqueFileNames([
+    { dataURL: "", fileName: "a.png" },
+    { dataURL: "", fileName: "a.png" },
+    { dataURL: "", fileName: "a.png" },
+  ]).map((img) => img.fileName);
+
+  expect(viaCapture).toEqual(["a.png", "a-2.png", "a-3.png"]);
+  expect(viaDownload).toEqual(viaCapture);
+});

--- a/src/capture/download-images.ts
+++ b/src/capture/download-images.ts
@@ -1,6 +1,7 @@
 import { Config, Image, Label } from "../types";
 import JSZip from "jszip";
 import { defaultConfig } from "../config";
+import { makeUnique } from "./make-unique";
 
 /**
  * downloadImages
@@ -93,36 +94,14 @@ function parseLabel(config: Config): Label {
  * ensureUniqueFileNames
  *
  * Ensures all image filenames are unique by adding -2, -3, etc. to duplicates
- * before the file extension.
+ * before the file extension. Uses the shared `makeUnique` helper so this public
+ * entry point dedups identically to capture-time naming.
  */
-function ensureUniqueFileNames(images: Image[]): Image[] {
-  const fileNameMap = new Map<string, number>();
+export function ensureUniqueFileNames(images: Image[]): Image[] {
+  const seen = new Set<string>();
 
   return images.map((image) => {
-    const { fileName } = image;
-
-    // Split the filename into base and extension
-    const lastDotIndex = fileName.lastIndexOf(".");
-    const baseName = lastDotIndex !== -1 ? fileName.substring(0, lastDotIndex) : fileName;
-    const extension = lastDotIndex !== -1 ? fileName.substring(lastDotIndex) : "";
-
-    // Check if this base filename has been seen before
-    if (!fileNameMap.has(fileName)) {
-      fileNameMap.set(fileName, 1);
-      return image;
-    }
-
-    // If it's a duplicate, increment the counter and create a new filename
-    const count = fileNameMap.get(fileName)! + 1;
-    fileNameMap.set(fileName, count);
-
-    // Create new filename with -2, -3, etc. before the extension
-    const newFileName = `${baseName}-${count}${extension}`;
-
-    // Return a new image object with the updated filename
-    return {
-      ...image,
-      fileName: newFileName,
-    };
+    const fileName = makeUnique(image.fileName, seen);
+    return fileName === image.fileName ? image : { ...image, fileName };
   });
 }

--- a/src/capture/handle-filenames.ts
+++ b/src/capture/handle-filenames.ts
@@ -1,54 +1,19 @@
 import { ImageOptions, Label } from "../types";
+import { makeUnique } from "./make-unique";
 
 /**
- * Handles the generation of unique filenames based on a proposed filename and an array of existing filenames.
+ * handleFileNames
  *
- * If the proposed filename is unique, it is added to the filenames array and returned as-is.
- * If the proposed filename is not unique, the function will check if it already ends with a "-n" pattern.
- * If it does, the function will increment the number until a unique filename is found.
- * If it doesn't, the function will start with "-2" and increment the number until a unique filename is found.
+ * Builds the filename for an image from its options (label + optional scale +
+ * format extension), then ensures it is unique against `seen` via the shared
+ * `makeUnique` helper.
  */
-export function handleFileNames(imageOptions: ImageOptions, filenames: string[]): Label {
-  // Finish altering filenames before checking for uniqueness
+export function handleFileNames(imageOptions: ImageOptions, seen: Set<string>): Label {
   let proposedFilename = imageOptions.label;
   // Add scale to filename if includeScaleInLabel is true
   if (imageOptions.includeScaleInLabel) proposedFilename += `_@${imageOptions.scale}x`;
-  // Add format to filename last
-  const extension = `.${imageOptions.format}`;
-  proposedFilename += extension;
+  // Add format extension last
+  proposedFilename += `.${imageOptions.format}`;
 
-  // If filename is unique, add it to array and return as-is
-  if (!filenames.includes(proposedFilename)) {
-    filenames.push(proposedFilename);
-    return proposedFilename;
-  }
-
-  // Check if filename already ends with -n pattern
-  const numberPattern = /-(\d+)$/;
-  const match = proposedFilename.match(numberPattern);
-
-  if (match) {
-    // File ends with -n, increment the number until we find a unique name
-    const baseFilename = proposedFilename.replace(numberPattern, "");
-    let counter = parseInt(match[1], 10);
-
-    while (filenames.includes(`${baseFilename}-${counter}${extension}`)) {
-      counter++;
-    }
-
-    const newFilename = `${baseFilename}-${counter}${extension}`;
-    filenames.push(newFilename);
-    return newFilename;
-  } else {
-    // File doesn't end with -n, start with -2 and increment if needed
-    const baseFilename = proposedFilename.replace(extension, "");
-    let counter = 2;
-    while (filenames.includes(`${baseFilename}-${counter}${extension}`)) {
-      counter++;
-    }
-
-    const newFilename = `${baseFilename}-${counter}${extension}`;
-    filenames.push(newFilename);
-    return newFilename;
-  }
+  return makeUnique(proposedFilename, seen);
 }

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -47,7 +47,7 @@ export async function capture(
 
     /* --------------------------------- Capture -------------------------------- */
     let images: Image[] = [];
-    let filenames: string[] = [];
+    const seen = new Set<string>();
     let imageNumber = 1;
 
     for (const element of elements) {
@@ -65,7 +65,7 @@ export async function capture(
           const image = await captureElement(
             element,
             { ...imageOptions, scale: scale } as ParsedImageOptions,
-            filenames
+            seen
           );
 
           images.push(image);
@@ -78,7 +78,7 @@ export async function capture(
         const image = await captureElement(
           element,
           imageOptions as ParsedImageOptions,
-          filenames
+          seen
         );
 
         images.push(image);

--- a/src/capture/make-unique.node.test.ts
+++ b/src/capture/make-unique.node.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import { makeUnique } from "./make-unique";
+
+/**
+ * Bug #8: a single shared dedup helper, used by both the capture-time
+ * filename builder and the public downloadImages entry point.
+ */
+test("returns the name unchanged when unseen", () => {
+  const seen = new Set<string>();
+  expect(makeUnique("a.png", seen)).toBe("a.png");
+});
+
+test("appends -2, -3 for successive duplicates", () => {
+  const seen = new Set<string>();
+  expect(makeUnique("a.png", seen)).toBe("a.png");
+  expect(makeUnique("a.png", seen)).toBe("a-2.png");
+  expect(makeUnique("a.png", seen)).toBe("a-3.png");
+});
+
+test("continues numbering when the base already ends in -n", () => {
+  const seen = new Set<string>(["a-2.png"]);
+  // "a-2.png" is taken -> next should be a-3.png, not a-2-2.png
+  expect(makeUnique("a-2.png", seen)).toBe("a-3.png");
+});
+
+test("skips already-taken numbered names", () => {
+  const seen = new Set<string>(["a.png", "a-2.png", "a-3.png"]);
+  expect(makeUnique("a.png", seen)).toBe("a-4.png");
+});
+
+test("handles names without an extension", () => {
+  const seen = new Set<string>(["report"]);
+  expect(makeUnique("report", seen)).toBe("report-2");
+});

--- a/src/capture/make-unique.ts
+++ b/src/capture/make-unique.ts
@@ -1,0 +1,40 @@
+/**
+ * makeUnique
+ *
+ * Returns a filename guaranteed not to collide with any name in `seen`, and
+ * records the result in `seen`. Duplicates get a `-2`, `-3`, ... suffix before
+ * the extension. If the proposed name already ends with `-n`, numbering
+ * continues from there (e.g. `a-2.png` -> `a-3.png`) rather than nesting
+ * (`a-2-2.png`).
+ *
+ * Shared by `handleFileNames` (capture time) and `downloadImages` (public
+ * entry point) so both paths dedup identically.
+ */
+export function makeUnique(fileName: string, seen: Set<string>): string {
+  if (!seen.has(fileName)) {
+    seen.add(fileName);
+    return fileName;
+  }
+
+  const lastDot = fileName.lastIndexOf(".");
+  const base = lastDot !== -1 ? fileName.slice(0, lastDot) : fileName;
+  const extension = lastDot !== -1 ? fileName.slice(lastDot) : "";
+
+  // If the base already ends with -n, continue numbering from n + 1.
+  const match = base.match(/-(\d+)$/);
+  let stem = base;
+  let counter = 2;
+  if (match) {
+    stem = base.slice(0, -match[0].length);
+    counter = parseInt(match[1], 10) + 1;
+  }
+
+  let candidate = `${stem}-${counter}${extension}`;
+  while (seen.has(candidate)) {
+    counter++;
+    candidate = `${stem}-${counter}${extension}`;
+  }
+
+  seen.add(candidate);
+  return candidate;
+}


### PR DESCRIPTION
## Phase 2 · bug #8 — duplicate, divergent dedup logic

Stacked on #6.

Two separate dedup implementations existed:
- `handleFileNames` (capture time) — and its `-n` branch was **dead code** (regex-matched the name *with* extension, which never ends in `-n`).
- `ensureUniqueFileNames` (inside public `downloadImages`).

They could produce different results for the same collisions.

### Fix
- New `makeUnique(name, seen)` — single source of truth. Correctly continues numbering when a base already ends in `-n` (`a-2.png` → `a-3.png`, not `a-2-2.png`).
- Both call sites route through it. **Both kept** — `downloadImages` is public and must dedup for callers who never went through capture.
- Capture now threads a `Set<string>` instead of `string[]`.

### Red → Green
- `make-unique.node.test.ts` (TDD'd the new helper — red: module missing).
- `dedup-consistency.node.test.ts` proves both entry points now agree.
- All 16 tests green.