### PR TITLE
fix: stop emitting empty images on capture failure (#7)

### DIFF
--- a/src/capture/capture-element.dom.test.ts
+++ b/src/capture/capture-element.dom.test.ts
@@ -1,0 +1,46 @@
+import { test, expect, mock } from "bun:test";
+import { ParsedImageOptions } from "../types";
+
+/**
+ * Bug #7: when the renderer fails, captureElement must NOT silently return an
+ * empty image ({ dataURL: "", fileName: "" }) — that empty entry would get
+ * zipped/downloaded as a corrupt file. It should throw so the caller can
+ * handle (skip + log) it.
+ */
+
+// modern-screenshot is mocked so we control success/failure deterministically.
+let shouldThrow = false;
+mock.module("modern-screenshot", () => ({
+  domToJpeg: async () => {
+    if (shouldThrow) throw new Error("render failed");
+    return "data:image/jpeg;base64,AAA";
+  },
+  domToPng: async () => "data:image/png;base64,AAA",
+  domToSvg: async () => "data:image/svg+xml,AAA",
+  domToWebp: async () => "data:image/webp;base64,AAA",
+}));
+
+const { captureElement } = await import("./capture-element");
+
+const opts = (format: string): ParsedImageOptions =>
+  ({
+    label: "a",
+    format,
+    scale: 1,
+    quality: 1,
+    includeScaleInLabel: false,
+  } as ParsedImageOptions);
+
+test("throws when the renderer fails instead of returning an empty image", async () => {
+  shouldThrow = true;
+  const el = document.createElement("div");
+  await expect(captureElement(el, opts("jpg"), new Set())).rejects.toThrow();
+});
+
+test("returns a valid Image on success", async () => {
+  shouldThrow = false;
+  const el = document.createElement("div");
+  const img = await captureElement(el, opts("png"), new Set());
+  expect(img.dataURL).toBe("data:image/png;base64,AAA");
+  expect(img.fileName).toBe("a.png");
+});

--- a/src/capture/capture-element.ts
+++ b/src/capture/capture-element.ts
@@ -12,6 +12,9 @@ export async function captureElement(
   imageOptions: ParsedImageOptions,
   seen: Set<string>
 ): Promise<Image> {
+  // If element has no background and is a JPG, default to white background.
+  // Tracked outside the try so it can be restored in finally even on failure.
+  let cleanUpBackground = false;
   try {
     let dataURL = "";
     // Final settings for capturing images.
@@ -24,11 +27,9 @@ export async function captureElement(
       filter: filter,
     };
 
-    // If element has no background and is a JPG, default to white background
     const styles = getComputedStyle(element);
     const backgroundColor = styles.backgroundColor;
     const backgroundImage = styles.backgroundImage;
-    let cleanUpBackground = false;
     if (
       backgroundColor === "rgba(0, 0, 0, 0)" &&
       backgroundImage === "none" &&
@@ -54,18 +55,22 @@ export async function captureElement(
         break;
     }
 
-    if (cleanUpBackground) {
-      element.style.backgroundColor = "";
-      element.style.backgroundImage = "";
-    }
-
     return {
       dataURL,
       fileName: handleFileNames(imageOptions, seen),
     };
   } catch (error) {
-    console.error("ImageExporter: Error in captureImage", error);
-    return { dataURL: "", fileName: "" };
+    // Do NOT swallow into an empty image — that produces a corrupt download.
+    // Rethrow with context so the caller can skip + log this element.
+    throw new Error(
+      `ImageExporter: failed to capture element as ${imageOptions.format}`,
+      { cause: error }
+    );
+  } finally {
+    if (cleanUpBackground) {
+      element.style.backgroundColor = "";
+      element.style.backgroundImage = "";
+    }
   }
 }
 

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -50,6 +50,23 @@ export async function capture(
     const seen = new Set<string>();
     let imageNumber = 1;
 
+    /**
+     * Captures one element+scale, pushing the result on success. On failure it
+     * logs and skips so one bad element can't abort the batch or emit a corrupt
+     * (empty) image into the results.
+     */
+    const tryCapture = async (
+      element: HTMLElement,
+      options: ParsedImageOptions
+    ): Promise<void> => {
+      log.progress(imageNumber++, totalElements);
+      try {
+        images.push(await captureElement(element, options, seen));
+      } catch (error) {
+        log.error(error);
+      }
+    };
+
     for (const element of elements) {
       const imageOptions = await getImageOptions(element, config);
       log.verbose("Image options", imageOptions);
@@ -61,27 +78,16 @@ export async function capture(
         imageOptions.includeScaleInLabel = true;
 
         for (const scale of imageOptions.scale) {
-          log.progress(imageNumber++, totalElements);
-          const image = await captureElement(
-            element,
-            { ...imageOptions, scale: scale } as ParsedImageOptions,
-            seen
-          );
-
-          images.push(image);
+          await tryCapture(element, {
+            ...imageOptions,
+            scale,
+          } as ParsedImageOptions);
         }
       } else if (typeof imageOptions.scale === "number") {
-        log.progress(imageNumber++, totalElements);
         /* -------------------------- Single scale capture -------------------------- */
         log.verbose("Single-scale capture");
 
-        const image = await captureElement(
-          element,
-          imageOptions as ParsedImageOptions,
-          seen
-        );
-
-        images.push(image);
+        await tryCapture(element, imageOptions as ParsedImageOptions);
       }
     }
 


### PR DESCRIPTION
## Phase 2 · bug #7 — silent broken images

Stacked on #7.

`captureElement` swallowed render errors and returned `{ dataURL: "", fileName: "" }`. That empty entry got zipped/downloaded as a **corrupt file**, with no error surfaced.

### Fix
- `captureElement` rethrows with context (`Error` `cause`) instead of returning an empty image.
- The temporary white-background style is now restored in a `finally` block, so it no longer leaks onto the live DOM element when capture throws.
- The capture loop catches **per element**: a failed element is logged and skipped — one failure can't abort the batch or corrupt the output.

### Testing
- happy-dom has no layout, so full `capture()` runs strip all elements; `captureElement` is unit-tested directly with `modern-screenshot` mocked.
- `capture-element.dom.test.ts`: throws on renderer failure (was red — used to resolve with an empty image), returns a valid Image on success.
- 18 tests green; build + declarations clean.