### PR TITLE
fix: make package import-safe in no-DOM/SSR contexts (#1)

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,8 @@
 import { windowLogging, loggingLevel } from "./capture";
 
+/** This package can be imported in non-DOM contexts (Node / SSR). */
+const hasWindow = typeof window !== "undefined";
+
 export const log = {
   info: (...messages: any[]) => logAction(messages, "info"),
   error: (...messages: any[]) => logAction(messages, "error"),
@@ -40,11 +43,12 @@ async function logAction(messages: any[], type: LogType = "info") {
       break;
   }
 
-  if (windowLogging) window.imageExporterLogs.push({ message: combinedMessage, type });
+  if (windowLogging && hasWindow)
+    window.imageExporterLogs.push({ message: combinedMessage, type });
 }
 
 async function logProgress(progress: number, total: number) {
-  if (windowLogging) {
+  if (windowLogging && hasWindow) {
     window.imageExporterProgress.push([progress, total]);
   }
 }
@@ -67,5 +71,7 @@ declare global {
   }
 }
 
-window.imageExporterLogs = [];
-window.imageExporterProgress = [];
+if (hasWindow) {
+  window.imageExporterLogs = [];
+  window.imageExporterProgress = [];
+}

--- a/test/ssr.node.test.ts
+++ b/test/ssr.node.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+
+/**
+ * Bug #1: importing the package must not crash in a no-DOM environment
+ * (Node / SSR frameworks like Next, Nuxt, SvelteKit). The logger wrote to
+ * `window` at module top-level with no guard, throwing `window is not defined`
+ * on import.
+ *
+ * This test runs WITHOUT happy-dom (test:node), so `window` is genuinely
+ * undefined — the only environment that reproduces the bug.
+ */
+test("package imports without a DOM (SSR-safe)", async () => {
+  expect(typeof window).toBe("undefined"); // sanity: truly no DOM here
+
+  const mod = await import("../src/index");
+
+  expect(typeof mod.capture).toBe("function");
+  expect(typeof mod.downloadImages).toBe("function");
+});


### PR DESCRIPTION
## Phase 2 · bug #1 — SSR import crash

Stacked on #8.

`logger.ts` wrote `window.imageExporterLogs`/`Progress` at module top-level with no guard. Importing the package in Node or any SSR framework threw `window is not defined` — a hard adoption blocker.

### Fix
- `const hasWindow = typeof window !== "undefined"` guard around all three `window` touch points (top-level init + the two `push` sites).

### Why happy-dom couldn't catch this
happy-dom injects a global `window`, masking the bug. This is exactly why Phase 1 set up a **no-DOM** test path — `test/ssr.node.test.ts` imports the package with `window` genuinely `undefined` (was red: `ReferenceError` at `logger.ts:70`).

Confirmed deps (`modern-screenshot`, `jszip`) are already import-safe in Node, so this guard fully fixes SSR import. 19 tests green.