### PR TITLE
Phase 0-2: license/docs fixes, test harness, and six bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # image-exporter
 
 [![npm version](https://img.shields.io/npm/v/image-exporter.svg)](https://www.npmjs.com/package/image-exporter)
-[![license](https://img.shields.io/npm/l/image-exporter.svg)](https://github.com/briantuckerdesign/image-exporter/blob/main/LICENSE)
+[![license](https://img.shields.io/npm/l/image-exporter.svg)](https://github.com/briantuckerdesign/image-exporter/blob/main/LICENSE.md)
 
 A client-side JavaScript tool that downloads DOM elements as images. It can be imported using your favorite package manager or attached directly to the window.
 
@@ -34,7 +34,11 @@ const images = await capture(artboards, {
 ### Browser
 
 ```html
-<script src="your-path/image-exporter.umd.js" type="text/javascript"></script>
+<!-- Self-hosted -->
+<script src="your-path/index.browser.js" type="text/javascript"></script>
+
+<!-- Or via CDN -->
+<script src="https://unpkg.com/image-exporter" type="text/javascript"></script>
 
 <div class="artboard">I will be downloaded.</div>
 
@@ -186,4 +190,4 @@ Bundled with Bun and written in TypeScript.
 
 ## License
 
-ISC License - see [LICENSE](LICENSE) for details.
+Apache-2.0 License - see [LICENSE.md](LICENSE.md) for details.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "build": "bun run scripts/build.ts",
+    "test": "bun run test:dom && bun run test:node",
+    "test:dom": "bun test --preload ./test/happydom.ts dom.test",
+    "test:node": "bun test node.test",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "prepublishOnly": "bun run build"
   },
   "repository": {
@@ -51,6 +55,8 @@
     "modern-screenshot": "^4.6.0"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.10.6",
+    "@types/bun": "^1.3.14",
     "concurrently": "^9.1.2",
     "http-server": "^14.1.1",
     "typescript": "^5.7.3"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "browser": "./dist/index.browser.js",
+  "unpkg": "./dist/index.browser.js",
+  "jsdelivr": "./dist/index.browser.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -39,7 +41,7 @@
     "gennyflow"
   ],
   "author": "Brian Tucker",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/briantuckerdesign/image-exporter/issues"
   },

--- a/src/capture/capture-element.dom.test.ts
+++ b/src/capture/capture-element.dom.test.ts
@@ -1,0 +1,46 @@
+import { test, expect, mock } from "bun:test";
+import { ParsedImageOptions } from "../types";
+
+/**
+ * Bug #7: when the renderer fails, captureElement must NOT silently return an
+ * empty image ({ dataURL: "", fileName: "" }) — that empty entry would get
+ * zipped/downloaded as a corrupt file. It should throw so the caller can
+ * handle (skip + log) it.
+ */
+
+// modern-screenshot is mocked so we control success/failure deterministically.
+let shouldThrow = false;
+mock.module("modern-screenshot", () => ({
+  domToJpeg: async () => {
+    if (shouldThrow) throw new Error("render failed");
+    return "data:image/jpeg;base64,AAA";
+  },
+  domToPng: async () => "data:image/png;base64,AAA",
+  domToSvg: async () => "data:image/svg+xml,AAA",
+  domToWebp: async () => "data:image/webp;base64,AAA",
+}));
+
+const { captureElement } = await import("./capture-element");
+
+const opts = (format: string): ParsedImageOptions =>
+  ({
+    label: "a",
+    format,
+    scale: 1,
+    quality: 1,
+    includeScaleInLabel: false,
+  } as ParsedImageOptions);
+
+test("throws when the renderer fails instead of returning an empty image", async () => {
+  shouldThrow = true;
+  const el = document.createElement("div");
+  await expect(captureElement(el, opts("jpg"), new Set())).rejects.toThrow();
+});
+
+test("returns a valid Image on success", async () => {
+  shouldThrow = false;
+  const el = document.createElement("div");
+  const img = await captureElement(el, opts("png"), new Set());
+  expect(img.dataURL).toBe("data:image/png;base64,AAA");
+  expect(img.fileName).toBe("a.png");
+});

--- a/src/capture/capture-element.ts
+++ b/src/capture/capture-element.ts
@@ -10,7 +10,7 @@ import * as modernScreenshot from "modern-screenshot";
 export async function captureElement(
   element: HTMLElement,
   imageOptions: ParsedImageOptions,
-  filenames: string[]
+  seen: Set<string>
 ): Promise<Image> {
   try {
     let dataURL = "";
@@ -61,7 +61,7 @@ export async function captureElement(
 
     return {
       dataURL,
-      fileName: handleFileNames(imageOptions, filenames),
+      fileName: handleFileNames(imageOptions, seen),
     };
   } catch (error) {
     console.error("ImageExporter: Error in captureImage", error);

--- a/src/capture/capture-element.ts
+++ b/src/capture/capture-element.ts
@@ -12,6 +12,9 @@ export async function captureElement(
   imageOptions: ParsedImageOptions,
   seen: Set<string>
 ): Promise<Image> {
+  // If element has no background and is a JPG, default to white background.
+  // Tracked outside the try so it can be restored in finally even on failure.
+  let cleanUpBackground = false;
   try {
     let dataURL = "";
     // Final settings for capturing images.
@@ -24,11 +27,9 @@ export async function captureElement(
       filter: filter,
     };
 
-    // If element has no background and is a JPG, default to white background
     const styles = getComputedStyle(element);
     const backgroundColor = styles.backgroundColor;
     const backgroundImage = styles.backgroundImage;
-    let cleanUpBackground = false;
     if (
       backgroundColor === "rgba(0, 0, 0, 0)" &&
       backgroundImage === "none" &&
@@ -54,18 +55,22 @@ export async function captureElement(
         break;
     }
 
-    if (cleanUpBackground) {
-      element.style.backgroundColor = "";
-      element.style.backgroundImage = "";
-    }
-
     return {
       dataURL,
       fileName: handleFileNames(imageOptions, seen),
     };
   } catch (error) {
-    console.error("ImageExporter: Error in captureImage", error);
-    return { dataURL: "", fileName: "" };
+    // Do NOT swallow into an empty image — that produces a corrupt download.
+    // Rethrow with context so the caller can skip + log this element.
+    throw new Error(
+      `ImageExporter: failed to capture element as ${imageOptions.format}`,
+      { cause: error }
+    );
+  } finally {
+    if (cleanUpBackground) {
+      element.style.backgroundColor = "";
+      element.style.backgroundImage = "";
+    }
   }
 }
 

--- a/src/capture/cors-cleanup.dom.test.ts
+++ b/src/capture/cors-cleanup.dom.test.ts
@@ -1,0 +1,34 @@
+import { test, expect, mock } from "bun:test";
+
+/**
+ * Bug #6: the CORS proxy mutates the live DOM (rewrites img.src, swaps <link>
+ * stylesheets for inline <style>). cleanUp() must run even if capture throws
+ * afterwards, otherwise the user's page is left broken. cleanUp therefore
+ * belongs in a finally block, not the success path.
+ *
+ * We mock the proxy so `run` throws; cleanUp should still be called.
+ */
+const cleanUp = mock(async () => {});
+mock.module("../cors-proxy", () => ({
+  corsProxy: {
+    run: async () => {
+      throw new Error("proxy boom");
+    },
+    cleanUp,
+  },
+}));
+
+const { capture } = await import("./index");
+
+test("corsProxy.cleanUp runs even when capture throws", async () => {
+  cleanUp.mockClear();
+  const el = document.createElement("div");
+
+  const result = await capture(el, {
+    corsProxyBaseUrl: "https://proxy.example/",
+    enableWindowLogging: false,
+  });
+
+  expect(result).toBeNull(); // run() threw -> top-level catch returns null
+  expect(cleanUp).toHaveBeenCalled(); // cleanup still happened via finally
+});

--- a/src/capture/dedup-consistency.node.test.ts
+++ b/src/capture/dedup-consistency.node.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+import { handleFileNames } from "./handle-filenames";
+import { ensureUniqueFileNames } from "./download-images";
+import { ImageOptions } from "../types";
+
+/**
+ * Bug #8: capture-time naming (handleFileNames) and the public downloadImages
+ * dedup (ensureUniqueFileNames) must produce identical results for the same
+ * set of colliding names, since both now use the shared makeUnique helper.
+ */
+const opts: ImageOptions = {
+  label: "a",
+  format: "png",
+  scale: 1,
+  quality: 1,
+  includeScaleInLabel: false,
+};
+
+test("both dedup paths agree on three colliding names", () => {
+  const seen = new Set<string>();
+  const viaCapture = [
+    handleFileNames(opts, seen),
+    handleFileNames(opts, seen),
+    handleFileNames(opts, seen),
+  ];
+
+  const viaDownload = ensureUniqueFileNames([
+    { dataURL: "", fileName: "a.png" },
+    { dataURL: "", fileName: "a.png" },
+    { dataURL: "", fileName: "a.png" },
+  ]).map((img) => img.fileName);
+
+  expect(viaCapture).toEqual(["a.png", "a-2.png", "a-3.png"]);
+  expect(viaDownload).toEqual(viaCapture);
+});

--- a/src/capture/determine-total-elements.dom.test.ts
+++ b/src/capture/determine-total-elements.dom.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test";
+import { determineTotalElements } from "./determine-total-elements";
+import { defaultConfig } from "../config";
+
+function div(scale?: string): HTMLElement {
+  const el = document.createElement("div");
+  if (scale !== undefined) el.dataset.scale = scale;
+  return el;
+}
+
+/**
+ * Bug #5: progress total must match the number of captures that will actually
+ * happen. Each element captures at least once; a comma-list captures once per
+ * scale. The old version skipped (counted 0 for) elements with no data-scale.
+ */
+test("element with no data-scale counts as 1", async () => {
+  expect(await determineTotalElements([div()], defaultConfig)).toBe(1);
+});
+
+test("element with a single scale counts as 1", async () => {
+  expect(await determineTotalElements([div("2")], defaultConfig)).toBe(1);
+});
+
+test("element with a multi-scale list counts once per scale", async () => {
+  expect(await determineTotalElements([div("1,2,3")], defaultConfig)).toBe(3);
+});
+
+test("invalid scale falls back to one capture", async () => {
+  expect(await determineTotalElements([div("nope")], defaultConfig)).toBe(1);
+});
+
+test("mixed elements sum correctly", async () => {
+  const els = [div(), div("1,2"), div("nope")]; // 1 + 2 + 1
+  expect(await determineTotalElements(els, defaultConfig)).toBe(4);
+});
+
+test("no data-scale uses config.scale array length", async () => {
+  const config = { ...defaultConfig, scale: [1, 2] };
+  expect(await determineTotalElements([div()], config)).toBe(2);
+});

--- a/src/capture/determine-total-elements.ts
+++ b/src/capture/determine-total-elements.ts
@@ -1,40 +1,54 @@
+import { Config } from "../types";
+
 /**
  * determineTotalElements
  *
- * Just used for progress logging to show progress of all element captures.
+ * Computes how many captures will occur across all elements, so progress
+ * logging reflects multi-scale captures (not just elements.length).
  *
- * This emcompasses multi-scale captures unlike elements.length.
+ * Each element produces at least one capture. A `data-scale` comma-list
+ * produces one capture per scale. An element with no (or an invalid)
+ * `data-scale` falls back to `config.scale`, mirroring `getImageOptions`.
  */
 export async function determineTotalElements(
-  elements: HTMLElement[] | NodeListOf<HTMLElement>
+  elements: HTMLElement[] | NodeListOf<HTMLElement>,
+  config: Config
 ): Promise<number> {
   try {
     let totalElements = 0;
-
-    for (const element of elements) {
-      const scaleAsString = element.dataset.scale;
-      if (!scaleAsString) continue;
-
-      if (scaleAsString.includes(",")) {
-        const scales = scaleAsString
-          .trim()
-          .split(",")
-          .map((scale) => parseFloat(scale));
-
-        if (scales.some((scale) => isNaN(scale))) continue;
-        totalElements += scales.length;
-      } else {
-        const scaleAsNumber = parseFloat(scaleAsString.trim());
-        if (isNaN(scaleAsNumber)) {
-          continue;
-        } else {
-          totalElements++;
-        }
-      }
+    for (const element of Array.from(elements)) {
+      totalElements += countScalesForElement(element, config);
     }
-
     return totalElements;
   } catch (error) {
     return 1;
   }
+}
+
+/** Number of captures a single element will produce. */
+function countScalesForElement(element: HTMLElement, config: Config): number {
+  const scaleAsString = element.dataset.scale;
+
+  // No override: use the configured default scale.
+  if (!scaleAsString) return countConfigScale(config);
+
+  if (scaleAsString.includes(",")) {
+    const scales = scaleAsString
+      .trim()
+      .split(",")
+      .map((scale) => parseFloat(scale));
+    // Invalid list -> getImageOptions falls back to config.scale.
+    if (scales.some((scale) => isNaN(scale))) return countConfigScale(config);
+    return scales.length;
+  }
+
+  const scaleAsNumber = parseFloat(scaleAsString.trim());
+  // Invalid single value -> getImageOptions falls back to config.scale.
+  if (isNaN(scaleAsNumber)) return countConfigScale(config);
+  return 1;
+}
+
+/** Captures implied by the config's default scale (array => one per scale). */
+function countConfigScale(config: Config): number {
+  return Array.isArray(config.scale) ? config.scale.length : 1;
 }

--- a/src/capture/download-images.ts
+++ b/src/capture/download-images.ts
@@ -1,6 +1,7 @@
 import { Config, Image, Label } from "../types";
 import JSZip from "jszip";
 import { defaultConfig } from "../config";
+import { makeUnique } from "./make-unique";
 
 /**
  * downloadImages
@@ -93,36 +94,14 @@ function parseLabel(config: Config): Label {
  * ensureUniqueFileNames
  *
  * Ensures all image filenames are unique by adding -2, -3, etc. to duplicates
- * before the file extension.
+ * before the file extension. Uses the shared `makeUnique` helper so this public
+ * entry point dedups identically to capture-time naming.
  */
-function ensureUniqueFileNames(images: Image[]): Image[] {
-  const fileNameMap = new Map<string, number>();
+export function ensureUniqueFileNames(images: Image[]): Image[] {
+  const seen = new Set<string>();
 
   return images.map((image) => {
-    const { fileName } = image;
-
-    // Split the filename into base and extension
-    const lastDotIndex = fileName.lastIndexOf(".");
-    const baseName = lastDotIndex !== -1 ? fileName.substring(0, lastDotIndex) : fileName;
-    const extension = lastDotIndex !== -1 ? fileName.substring(lastDotIndex) : "";
-
-    // Check if this base filename has been seen before
-    if (!fileNameMap.has(fileName)) {
-      fileNameMap.set(fileName, 1);
-      return image;
-    }
-
-    // If it's a duplicate, increment the counter and create a new filename
-    const count = fileNameMap.get(fileName)! + 1;
-    fileNameMap.set(fileName, count);
-
-    // Create new filename with -2, -3, etc. before the extension
-    const newFileName = `${baseName}-${count}${extension}`;
-
-    // Return a new image object with the updated filename
-    return {
-      ...image,
-      fileName: newFileName,
-    };
+    const fileName = makeUnique(image.fileName, seen);
+    return fileName === image.fileName ? image : { ...image, fileName };
   });
 }

--- a/src/capture/get-image-options.dom.test.ts
+++ b/src/capture/get-image-options.dom.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, spyOn } from "bun:test";
+import { getImageOptions } from "./get-image-options";
+import { defaultConfig } from "../config";
+
+/**
+ * Bug #9: when an invalid format is provided, the error message must list ALL
+ * accepted formats. webp is supported but was missing from the message.
+ */
+test("invalid format error message lists webp as an accepted value", async () => {
+  const el = document.createElement("div");
+  el.dataset.format = "gif"; // not supported -> triggers the error path
+
+  const spy = spyOn(console, "error").mockImplementation(() => {});
+  await getImageOptions(el, defaultConfig);
+  const logged = spy.mock.calls
+    .map((args) => args.map((a) => String(a)).join(" "))
+    .join("\n");
+  spy.mockRestore();
+
+  expect(logged).toContain("webp");
+});
+
+test("invalid format falls back to the config default", async () => {
+  const el = document.createElement("div");
+  el.dataset.format = "gif";
+
+  const spy = spyOn(console, "error").mockImplementation(() => {});
+  const options = await getImageOptions(el, defaultConfig);
+  spy.mockRestore();
+
+  expect(options.format).toBe(defaultConfig.format);
+});

--- a/src/capture/get-image-options.ts
+++ b/src/capture/get-image-options.ts
@@ -94,7 +94,7 @@ export async function getImageOptions(
           `ImageExporter: provided format is not valid.
             Provided: ${format}
             Element: ${element}
-            Accepted values: jpg, png, svg, 
+            Accepted values: jpg, png, svg, webp
             Defaulting to: ${config.format}`
         );
       }

--- a/src/capture/handle-filenames.ts
+++ b/src/capture/handle-filenames.ts
@@ -1,54 +1,19 @@
 import { ImageOptions, Label } from "../types";
+import { makeUnique } from "./make-unique";
 
 /**
- * Handles the generation of unique filenames based on a proposed filename and an array of existing filenames.
+ * handleFileNames
  *
- * If the proposed filename is unique, it is added to the filenames array and returned as-is.
- * If the proposed filename is not unique, the function will check if it already ends with a "-n" pattern.
- * If it does, the function will increment the number until a unique filename is found.
- * If it doesn't, the function will start with "-2" and increment the number until a unique filename is found.
+ * Builds the filename for an image from its options (label + optional scale +
+ * format extension), then ensures it is unique against `seen` via the shared
+ * `makeUnique` helper.
  */
-export function handleFileNames(imageOptions: ImageOptions, filenames: string[]): Label {
-  // Finish altering filenames before checking for uniqueness
+export function handleFileNames(imageOptions: ImageOptions, seen: Set<string>): Label {
   let proposedFilename = imageOptions.label;
   // Add scale to filename if includeScaleInLabel is true
   if (imageOptions.includeScaleInLabel) proposedFilename += `_@${imageOptions.scale}x`;
-  // Add format to filename last
-  const extension = `.${imageOptions.format}`;
-  proposedFilename += extension;
+  // Add format extension last
+  proposedFilename += `.${imageOptions.format}`;
 
-  // If filename is unique, add it to array and return as-is
-  if (!filenames.includes(proposedFilename)) {
-    filenames.push(proposedFilename);
-    return proposedFilename;
-  }
-
-  // Check if filename already ends with -n pattern
-  const numberPattern = /-(\d+)$/;
-  const match = proposedFilename.match(numberPattern);
-
-  if (match) {
-    // File ends with -n, increment the number until we find a unique name
-    const baseFilename = proposedFilename.replace(numberPattern, "");
-    let counter = parseInt(match[1], 10);
-
-    while (filenames.includes(`${baseFilename}-${counter}${extension}`)) {
-      counter++;
-    }
-
-    const newFilename = `${baseFilename}-${counter}${extension}`;
-    filenames.push(newFilename);
-    return newFilename;
-  } else {
-    // File doesn't end with -n, start with -2 and increment if needed
-    const baseFilename = proposedFilename.replace(extension, "");
-    let counter = 2;
-    while (filenames.includes(`${baseFilename}-${counter}${extension}`)) {
-      counter++;
-    }
-
-    const newFilename = `${baseFilename}-${counter}${extension}`;
-    filenames.push(newFilename);
-    return newFilename;
-  }
+  return makeUnique(proposedFilename, seen);
 }

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -47,7 +47,7 @@ export async function capture(
 
     /* --------------------------------- Capture -------------------------------- */
     let images: Image[] = [];
-    let filenames: string[] = [];
+    const seen = new Set<string>();
     let imageNumber = 1;
 
     for (const element of elements) {
@@ -65,7 +65,7 @@ export async function capture(
           const image = await captureElement(
             element,
             { ...imageOptions, scale: scale } as ParsedImageOptions,
-            filenames
+            seen
           );
 
           images.push(image);
@@ -78,7 +78,7 @@ export async function capture(
         const image = await captureElement(
           element,
           imageOptions as ParsedImageOptions,
-          filenames
+          seen
         );
 
         images.push(image);

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -50,6 +50,23 @@ export async function capture(
     const seen = new Set<string>();
     let imageNumber = 1;
 
+    /**
+     * Captures one element+scale, pushing the result on success. On failure it
+     * logs and skips so one bad element can't abort the batch or emit a corrupt
+     * (empty) image into the results.
+     */
+    const tryCapture = async (
+      element: HTMLElement,
+      options: ParsedImageOptions
+    ): Promise<void> => {
+      log.progress(imageNumber++, totalElements);
+      try {
+        images.push(await captureElement(element, options, seen));
+      } catch (error) {
+        log.error(error);
+      }
+    };
+
     for (const element of elements) {
       const imageOptions = await getImageOptions(element, config);
       log.verbose("Image options", imageOptions);
@@ -61,27 +78,16 @@ export async function capture(
         imageOptions.includeScaleInLabel = true;
 
         for (const scale of imageOptions.scale) {
-          log.progress(imageNumber++, totalElements);
-          const image = await captureElement(
-            element,
-            { ...imageOptions, scale: scale } as ParsedImageOptions,
-            seen
-          );
-
-          images.push(image);
+          await tryCapture(element, {
+            ...imageOptions,
+            scale,
+          } as ParsedImageOptions);
         }
       } else if (typeof imageOptions.scale === "number") {
-        log.progress(imageNumber++, totalElements);
         /* -------------------------- Single scale capture -------------------------- */
         log.verbose("Single-scale capture");
 
-        const image = await captureElement(
-          element,
-          imageOptions as ParsedImageOptions,
-          seen
-        );
-
-        images.push(image);
+        await tryCapture(element, imageOptions as ParsedImageOptions);
       }
     }
 

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -94,15 +94,16 @@ export async function capture(
     /* -------------------------------- Download -------------------------------- */
     if (config.downloadImages) await downloadImages(images, config);
 
-    /* --------------------------- Clean up CORS proxy -------------------------- */
-    if (userConfig.corsProxyBaseUrl) await corsProxy.cleanUp();
-
     /** Return images optionally */
     return images;
   } catch (error) {
     log.error(error);
     return null;
   } finally {
+    /* --------------------------- Clean up CORS proxy -------------------------- */
+    // In finally so the live DOM is always restored, even if capture threw
+    // after the proxy mutated it.
+    if (userConfig.corsProxyBaseUrl) await corsProxy.cleanUp();
     log.group.close();
   }
 }

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -33,7 +33,7 @@ export async function capture(
     const originalLength = elements.length;
     elements = removeHiddenElements(elements);
 
-    const totalElements = await determineTotalElements(elements);
+    const totalElements = await determineTotalElements(elements, config);
 
     if (originalLength !== elements.length)
       log.verbose(

--- a/src/capture/make-unique.node.test.ts
+++ b/src/capture/make-unique.node.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import { makeUnique } from "./make-unique";
+
+/**
+ * Bug #8: a single shared dedup helper, used by both the capture-time
+ * filename builder and the public downloadImages entry point.
+ */
+test("returns the name unchanged when unseen", () => {
+  const seen = new Set<string>();
+  expect(makeUnique("a.png", seen)).toBe("a.png");
+});
+
+test("appends -2, -3 for successive duplicates", () => {
+  const seen = new Set<string>();
+  expect(makeUnique("a.png", seen)).toBe("a.png");
+  expect(makeUnique("a.png", seen)).toBe("a-2.png");
+  expect(makeUnique("a.png", seen)).toBe("a-3.png");
+});
+
+test("continues numbering when the base already ends in -n", () => {
+  const seen = new Set<string>(["a-2.png"]);
+  // "a-2.png" is taken -> next should be a-3.png, not a-2-2.png
+  expect(makeUnique("a-2.png", seen)).toBe("a-3.png");
+});
+
+test("skips already-taken numbered names", () => {
+  const seen = new Set<string>(["a.png", "a-2.png", "a-3.png"]);
+  expect(makeUnique("a.png", seen)).toBe("a-4.png");
+});
+
+test("handles names without an extension", () => {
+  const seen = new Set<string>(["report"]);
+  expect(makeUnique("report", seen)).toBe("report-2");
+});

--- a/src/capture/make-unique.ts
+++ b/src/capture/make-unique.ts
@@ -1,0 +1,40 @@
+/**
+ * makeUnique
+ *
+ * Returns a filename guaranteed not to collide with any name in `seen`, and
+ * records the result in `seen`. Duplicates get a `-2`, `-3`, ... suffix before
+ * the extension. If the proposed name already ends with `-n`, numbering
+ * continues from there (e.g. `a-2.png` -> `a-3.png`) rather than nesting
+ * (`a-2-2.png`).
+ *
+ * Shared by `handleFileNames` (capture time) and `downloadImages` (public
+ * entry point) so both paths dedup identically.
+ */
+export function makeUnique(fileName: string, seen: Set<string>): string {
+  if (!seen.has(fileName)) {
+    seen.add(fileName);
+    return fileName;
+  }
+
+  const lastDot = fileName.lastIndexOf(".");
+  const base = lastDot !== -1 ? fileName.slice(0, lastDot) : fileName;
+  const extension = lastDot !== -1 ? fileName.slice(lastDot) : "";
+
+  // If the base already ends with -n, continue numbering from n + 1.
+  const match = base.match(/-(\d+)$/);
+  let stem = base;
+  let counter = 2;
+  if (match) {
+    stem = base.slice(0, -match[0].length);
+    counter = parseInt(match[1], 10) + 1;
+  }
+
+  let candidate = `${stem}-${counter}${extension}`;
+  while (seen.has(candidate)) {
+    counter++;
+    candidate = `${stem}-${counter}${extension}`;
+  }
+
+  seen.add(candidate);
+  return candidate;
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,8 @@
 import { windowLogging, loggingLevel } from "./capture";
 
+/** This package can be imported in non-DOM contexts (Node / SSR). */
+const hasWindow = typeof window !== "undefined";
+
 export const log = {
   info: (...messages: any[]) => logAction(messages, "info"),
   error: (...messages: any[]) => logAction(messages, "error"),
@@ -40,11 +43,12 @@ async function logAction(messages: any[], type: LogType = "info") {
       break;
   }
 
-  if (windowLogging) window.imageExporterLogs.push({ message: combinedMessage, type });
+  if (windowLogging && hasWindow)
+    window.imageExporterLogs.push({ message: combinedMessage, type });
 }
 
 async function logProgress(progress: number, total: number) {
-  if (windowLogging) {
+  if (windowLogging && hasWindow) {
     window.imageExporterProgress.push([progress, total]);
   }
 }
@@ -67,5 +71,7 @@ declare global {
   }
 }
 
-window.imageExporterLogs = [];
-window.imageExporterProgress = [];
+if (hasWindow) {
+  window.imageExporterLogs = [];
+  window.imageExporterProgress = [];
+}

--- a/test/happydom.ts
+++ b/test/happydom.ts
@@ -1,0 +1,13 @@
+/**
+ * happy-dom preload for browser-style tests.
+ *
+ * Registers a lightweight DOM (window, document, etc.) onto globalThis so that
+ * code depending on the browser environment can run under `bun test`.
+ *
+ * Only loaded by the `test:dom` script via `--preload`. The `test:node` script
+ * deliberately does NOT load this, giving us a true no-DOM environment for
+ * testing SSR / server-side safety.
+ */
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();

--- a/test/smoke.dom.test.ts
+++ b/test/smoke.dom.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "bun:test";
+
+/**
+ * Smoke test for the DOM test environment.
+ *
+ * Proves that the happy-dom preload is active: `document` exists and we can
+ * create and query real elements. Real unit tests for capture logic build on
+ * this same environment.
+ */
+test("happy-dom is registered: document is available", () => {
+  expect(typeof window).toBe("object");
+  expect(typeof document).toBe("object");
+
+  const el = document.createElement("div");
+  el.className = "artboard";
+  el.textContent = "hello";
+  document.body.appendChild(el);
+
+  expect(document.querySelector(".artboard")?.textContent).toBe("hello");
+
+  el.remove();
+});

--- a/test/smoke.node.test.ts
+++ b/test/smoke.node.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test";
+
+/**
+ * Smoke test for the no-DOM (Node / SSR) test environment.
+ *
+ * Proves that the `test:node` script runs WITHOUT happy-dom: there is no
+ * global `window`. This is the environment used to verify the package is safe
+ * to import in SSR / server contexts (Phase 2, bug #1).
+ */
+test("no-DOM environment: window is undefined", () => {
+  expect(typeof window).toBe("undefined");
+});

--- a/test/ssr.node.test.ts
+++ b/test/ssr.node.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test";
+
+/**
+ * Bug #1: importing the package must not crash in a no-DOM environment
+ * (Node / SSR frameworks like Next, Nuxt, SvelteKit). The logger wrote to
+ * `window` at module top-level with no guard, throwing `window is not defined`
+ * on import.
+ *
+ * This test runs WITHOUT happy-dom (test:node), so `window` is genuinely
+ * undefined — the only environment that reproduces the bug.
+ */
+test("package imports without a DOM (SSR-safe)", async () => {
+  expect(typeof window).toBe("undefined"); // sanity: truly no DOM here
+
+  const mod = await import("../src/index");
+
+  expect(typeof mod.capture).toBe("function");
+  expect(typeof mod.downloadImages).toBe("function");
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
Combined PR for Phase 0–2 of the modernization work (collapsed from a stacked chain into one for single-pass review).

## Phase 0 — config & docs
- license `ISC` → `Apache-2.0` (matches `LICENSE.md`); README badge/section updated
- fixed phantom `image-exporter.umd.js` reference → real `dist/index.browser.js` + CDN example
- added `unpkg`/`jsdelivr` fields

## Phase 1 — test harness
- `bun test` + `@happy-dom/global-registrator`
- **two environments**: `test:dom` (`*.dom.test.ts`, happy-dom) and `test:node` (`*.node.test.ts`, no DOM) — the no-DOM path is required so the SSR bug below can actually be reproduced
- `tsconfig.test.json` + `typecheck` script

## Phase 2 — six bug fixes (all test-first)
| # | Fix |
|---|-----|
| #9 | include `webp` in invalid-format error message |
| #5 | progress total counts every capture (multi-scale included) |
| #8 | unify filename dedup into one shared `makeUnique` helper |
| #7 | stop emitting empty images on capture failure (rethrow + per-element skip; restore bg in `finally`) |
| #1 | SSR import-safe (`window` guard in logger) |
| #6 | always restore CORS-proxied DOM via `finally` |

20 tests green; build + declarations + typecheck clean.

### Follow-up (Phase 3)
`bun.lock` is gitignored → not reproducible in CI. Will un-ignore + `--frozen-lockfile` when CI lands.