### PR TITLE
fix: run changeset version under Node (release was failing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,10 @@ jobs:
         uses: changesets/action@v1
         with:
           # `version` updates package.json + CHANGELOG from changesets.
-          version: bunx changeset version
+          # Run under Node (npx), not Bun: the GitHub-linked changelog generator
+          # fetches api.github.com/graphql, and Bun's fetch flakes with
+          # "Premature close" against it.
+          version: npx changeset version
           # `publish` runs only when there are version bumps to release.
           # `release` builds first, then publishes via npm (OIDC, no token).
           publish: bun run release


### PR DESCRIPTION
The Release workflow failed at `changeset version`: the GitHub-linked changelog generator fetches `api.github.com/graphql`, and Bun's fetch flakes with `Premature close`. Switch that step to `npx changeset version` (Node). Publish stays on Bun.